### PR TITLE
[Feature] Change single draw functionality to timed interval

### DIFF
--- a/packages/frontend/src/consts.ts
+++ b/packages/frontend/src/consts.ts
@@ -1,5 +1,6 @@
 import { MatchStat } from "./types";
 
+export const YEAR_CAP = 500;
 export const TICKET_PRICE = 300;
 export const LOWEST_MATCH_COUNT = 2;
 export const HIGHEST_MATCH_COUNT = 5;


### PR DESCRIPTION
### Frontend changes

- Adds a number input where the simulation interval can be changed
- Instead of single draws the main button starts/stops the simulation based on the defined interval
- Adds stop conditions (500 years or one jackpot)